### PR TITLE
Resolve crash for invalid URLs

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -6,6 +6,7 @@
 #endif
 
 static NSString * const NOT_AVAILABLE_ERROR_MESSAGE = @"WebKit/WebKit-Components are only available with iOS11 and higher!";
+static NSString * const INVALID_URL_MISSING_HTTP = @"Invalid URL: You may be missing http:// or https:// in your URL.";
 
 @implementation RNCookieManagerIOS
 
@@ -102,6 +103,11 @@ RCT_EXPORT_METHOD(getFromResponse:(NSURL *)url
     NSInteger maxLength = 2;
 
     NSURLComponents *components = [[NSURLComponents alloc]initWithURL:url resolvingAgainstBaseURL:FALSE];
+
+    if ([components.host isEqual: @""] || components.host == nil) {
+        return nil;
+    }
+
     NSArray<NSString *> *separatedHost = [components.host componentsSeparatedByString:separator];
     NSInteger count = [separatedHost count];
     NSInteger endPosition = count;
@@ -125,6 +131,11 @@ RCT_EXPORT_METHOD(
         if (@available(iOS 11.0, *)) {
             dispatch_async(dispatch_get_main_queue(), ^(){
                 NSString *topLevelDomain = [self getDomainName:url];
+
+                if (topLevelDomain == nil) {
+                    reject(@"", INVALID_URL_MISSING_HTTP, nil);
+                    return;
+                }
 
                 WKHTTPCookieStore *cookieStore = [[WKWebsiteDataStore defaultDataStore] httpCookieStore];
                 [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -6,7 +6,7 @@
 #endif
 
 static NSString * const NOT_AVAILABLE_ERROR_MESSAGE = @"WebKit/WebKit-Components are only available with iOS11 and higher!";
-static NSString * const INVALID_URL_MISSING_HTTP = @"Invalid URL: You may be missing http:// or https:// in your URL.";
+static NSString * const INVALID_URL_MISSING_HTTP = @"Invalid URL: It may be missing a protocol (ex. http:// or https://).";
 
 @implementation RNCookieManagerIOS
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fix for https://github.com/react-native-community/react-native-cookies/issues/9. Catch when `NSURLComponents` cannot resolve the URL.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
`CookieManager.get("google.com", true);` this should not crash.

### What are the steps to reproduce (after prerequisites)?
`CookieManager.get("google.com", true).catch(e => console.log(e));`

Should log `Invalid URL: You may be missing http:// or https:// in your URL.`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
